### PR TITLE
Allow for CRLF to be in message body.

### DIFF
--- a/errand_boy/transports/base.py
+++ b/errand_boy/transports/base.py
@@ -358,10 +358,16 @@ class BaseTransport(object):
 
             data += new_data
 
-            if CRLF in data:
-                split_data = data.split(CRLF)
-                lines.extend(split_data[:-1])
-                data = split_data[-1]
+            if not lines and CRLF in data:
+                try:
+                    headers, body = data.split(CRLF + CRLF, 1)
+                except ValueError:
+                    split_data = data.split(CRLF)
+                    lines.extend(split_data[:-1])
+                    data = split_data[-1]
+                else:
+                    lines.extend((headers + CRLF).split(CRLF))
+                    data = body
 
             if lines and content_length is None:
                 for line in lines:

--- a/tests/test_unixsocket_transport_live.py
+++ b/tests/test_unixsocket_transport_live.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 import errand_boy
+from errand_boy.constants import CRLF
 from errand_boy.exceptions import SessionClosedError
 from errand_boy.transports import base, unixsocket
 
@@ -33,6 +34,25 @@ class UNIXSocketTransportLiveTestCase(unittest.TestCase):
         transport = unixsocket.UNIXSocketTransport()
 
         str_data = (b'a' * 244544) + b'b'
+
+        with transport.get_session() as session:
+            foo = session.subprocess
+
+            process = foo.Popen(['cat'], stdin=foo.PIPE,
+                stdout=foo.PIPE,
+                stderr=foo.PIPE
+            )
+
+            res_stdout, res_stderr = process.communicate(str_data)
+
+            res_returncode = process.returncode
+
+        self.assertEqual(res_stdout, str_data)
+
+    def test_crlf_in_body(self):
+        transport = unixsocket.UNIXSocketTransport()
+
+        str_data = b'foo' + CRLF + b'bar'
 
         with transport.get_session() as session:
             foo = session.subprocess


### PR DESCRIPTION
My use-case required PDF files to be sent using errand-boy. If a CRLF occured it would split the body and cause a part of it to left as last element of the lines list, causing deadlocks.